### PR TITLE
Update 3rd party actions and use `npm ci`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,5 +22,5 @@ runs:
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: |
-        npm install
+        npm ci
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -6,27 +6,21 @@ description: |
 runs:
   using: composite
   steps:
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      id: nvm
-      shell: bash
 
-    - name: Setup NodeJS ${{ steps.nvm.outputs.NVMRC }}
-      uses: actions/setup-node@v2
+    - name: Setup NodeJS 
+      uses: actions/setup-node@v3
       with:
-        node-version: ${{ steps.nvm.outputs.NVMRC }}
+        node-version-file: '.nvmrc'
 
     - name: Cache dependencies
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
+      id: cache-node-modules
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
 
     - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: |
         npm install
       shell: bash


### PR DESCRIPTION
We were using old version of the setup-node and cache actions. Updating to latest versions. 
- setup-node@v3 includes support for checking the `.nvmrc` file so we're able to remove the "Read .nvmrc" step
- cache@v3 had a different implementation example than what we were using so updated to follow their recommended setup. 

I think we were using `npm install` in order to take advantage of the cache step. But if there isn't a cache hit an `npm install` can actually install versions of packages that are different than what is set in the package-lock.json. So skipping the step seems like a safer implementation. 